### PR TITLE
Stringable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Use their documentation to craft your menus as simple or complex as you like:
 * [Version 3](https://spatie.be/docs/menu/v3) (PHP 8 only)
 
 Create your menus by extending `Tatter\Menus\Menu`. You will notice in the source code that
-`Menu` requires you to provide one method: `public function get(): string;`. You may use the
+`Menu` requires you to provide one method: `public function __toString(): string;`. You may use the
 supplied `$builder` property to access the underlying `Spatie\Menu` to build your menu,
 or provide your own HTML code or `view()` return. Some examples:
 ```
 class MainMenu extends \Tatter\Menus\Menu
 {
-	public function get(): string
+	public function __toString(): string
 	{
 		return $this->builder
 			->link(site_url('/'), 'Home')
@@ -61,7 +61,7 @@ class MainMenu extends \Tatter\Menus\Menu
 
 class FruitMenu extends \Tatter\Menus\Menu
 {
-	public function get(): string
+	public function __toString(): string
 	{
 		return view('menus/fruit', ['active' => 'banana']);
 	}
@@ -75,7 +75,7 @@ relative and absolute URLs you must supply full URL values (e.g. with `site_url(
 
 ### Deploying
 
-Since `Menu->get()` returns a `string` it can be used in your view or layout files as is.
+Since `Menu` is `Stringable` it can be used in your view or layout files as is.
 However, **Menus** also comes with a [Controller Filter](https://codeigniter4.github.io/CodeIgniter4/incoming/filters.html)
 that you can use to inject menu content directly into your responses. First you need to create
 an alias for each `Menu` class you would like to use. Create **app/Config/Menus.php** (or

--- a/src/Filters/MenusFilter.php
+++ b/src/Filters/MenusFilter.php
@@ -68,7 +68,7 @@ class MenusFilter implements FilterInterface
 			}
 
 			// Grab the menu content
-			$content = (new $class)->get();
+			$content = (string) (new $class);
 			$count   = 0;
 
 			// Swap the content for the placeholder and verify a match

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -58,5 +58,5 @@ abstract class Menu
 	 *
 	 * @return string
 	 */
-	abstract public function get(): string;
+	abstract public function __toString(): string;
 }

--- a/tests/_support/Menus/TestMenu.php
+++ b/tests/_support/Menus/TestMenu.php
@@ -10,7 +10,7 @@ class TestMenu extends Menu
 	 *
 	 * @return string
 	 */
-	public function get(): string
+	public function __toString(): string
 	{
 		return 'bananas';
 	}

--- a/tests/menu/MenuTest.php
+++ b/tests/menu/MenuTest.php
@@ -21,7 +21,7 @@ class MenuTest extends MenusTestCase
 
 		$this->menu = new class extends Menu {
 
-			public function get(): string
+			public function __toString(): string
 			{
 				return $this->builder
 					->link(site_url('/'), 'Home')
@@ -42,13 +42,13 @@ class MenuTest extends MenusTestCase
 	{
 		$menu = new class(BaseMenu::new()->link(site_url('/home'), 'asparagus')) extends Menu {
 
-			public function get(): string
+			public function __toString(): string
 			{
 				return $this->builder->render();
 			}
 		};
 
-		$result = $menu->get();
+		$result = (string) $menu;
 
 		$this->assertSame('<ul><li><a href="http://example.com/home">asparagus</a></li></ul>', $result);
 	}
@@ -56,7 +56,7 @@ class MenuTest extends MenusTestCase
 	public function testGetUsesCurrentUrl()
 	{
 		$expected = '<ul><li><a href="http://example.com/">Home</a></li><li class="active exact-active"><a href="http://example.com/current">Grain</a></li></ul>';
-		$result   = $this->menu->get();
+		$result   = $this->menu->__toString();
 
 		$this->assertSame($expected, $result);
 	}

--- a/tests/menu/TraitsTest.php
+++ b/tests/menu/TraitsTest.php
@@ -12,7 +12,7 @@ class TraitsTest extends MenusTestCase
 
 			use Bootstrap;
 
-			public function get(): string
+			public function __toString(): string
 			{
 				return $this->builder
 					->link(site_url('/'), 'Home')
@@ -21,7 +21,7 @@ class TraitsTest extends MenusTestCase
 			}
 		};
 
-		$result = $menu->get();
+		$result = $menu->__toString();
 
 		$this->assertStringContainsString('li class="nav-item"', $result);
 		$this->assertStringContainsString('class="nav-link"', $result);


### PR DESCRIPTION
Switches `Menu`'s method off `get()` to `__toString()` to make classes `Stringable` and easier to use outside of the filter.